### PR TITLE
feat: add Corner Strategy agent

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -7,7 +7,13 @@ from datetime import datetime
 from typing import Optional
 
 from game2048.game import Game2048
-from game2048.agents import RandomAgent, RightLeftAgent, RightDownAgent, BaseAgent
+from game2048.agents import (
+    RandomAgent,
+    RightLeftAgent,
+    RightDownAgent,
+    CornerAgent,
+    BaseAgent,
+)
 from game2048.runner import GameRunner
 
 
@@ -97,6 +103,7 @@ def main():
         "random": RandomAgent(seed=42),
         "rightleft": RightLeftAgent(),
         "rightdown": RightDownAgent(),
+        "corner": CornerAgent(),
     }
 
     all_results: dict[str, list[dict]] = {}

--- a/game2048/agents/__init__.py
+++ b/game2048/agents/__init__.py
@@ -38,12 +38,14 @@ class BaseAgent:
 from game2048.agents.random_agent import RandomAgent
 from game2048.agents.rightleft_agent import RightLeftAgent
 from game2048.agents.rightdown_agent import RightDownAgent
+from game2048.agents.corner_agent import CornerAgent
 
 __all__ = [
     "BaseAgent",
     "RandomAgent",
     "RightLeftAgent",
     "RightDownAgent",
+    "CornerAgent",
     "register_agent",
     "get_agent",
     "list_agents",

--- a/game2048/agents/corner_agent.py
+++ b/game2048/agents/corner_agent.py
@@ -1,0 +1,19 @@
+from typing import Optional
+from game2048.game import Game2048
+from game2048.agents import register_agent, BaseAgent
+
+
+@register_agent("corner")
+class CornerAgent(BaseAgent):
+    def __init__(self, corner: str = "bottom-right"):
+        self.corner = corner
+        self.preferred = ["down", "right", "left", "up"]
+
+    def choose_move(self, game: Game2048) -> Optional[str]:
+        valid = game.get_valid_moves()
+        if not valid:
+            return None
+        for move in self.preferred:
+            if move in valid:
+                return move
+        return valid[0]

--- a/test_game.py
+++ b/test_game.py
@@ -1,6 +1,6 @@
 import unittest
 from game2048.game import Game2048
-from game2048.agents import RandomAgent, RightLeftAgent, RightDownAgent
+from game2048.agents import RandomAgent, RightLeftAgent, RightDownAgent, CornerAgent
 
 
 class TestGame2048(unittest.TestCase):
@@ -125,6 +125,35 @@ class TestRightDownAgent(unittest.TestCase):
     def test_play_game(self):
         game = Game2048(seed=42)
         agent = RightDownAgent()
+        final_score = agent.play_game(game)
+        self.assertTrue(game.game_over)
+        self.assertIsInstance(final_score, int)
+        self.assertGreater(final_score, 0)
+
+
+class TestCornerAgent(unittest.TestCase):
+    def test_agent_prefers_corner_moves(self):
+        game = Game2048(seed=42)
+        agent = CornerAgent()
+        self.assertEqual(agent.preferred, ["down", "right", "left", "up"])
+
+    def test_agent_returns_valid_move(self):
+        game = Game2048(seed=42)
+        agent = CornerAgent()
+        move = agent.choose_move(game)
+        self.assertIn(move, Game2048.MOVES)
+
+    def test_agent_fallback_behavior(self):
+        game = Game2048(seed=42)
+        game.grid = [[2, 2, 4, 8], [4, 2, 2, 4], [8, 4, 2, 2], [2, 4, 8, 4]]
+        game.game_over = False
+        agent = CornerAgent()
+        move = agent.choose_move(game)
+        self.assertIn(move, Game2048.MOVES)
+
+    def test_play_game(self):
+        game = Game2048(seed=42)
+        agent = CornerAgent()
         final_score = agent.play_game(game)
         self.assertTrue(game.game_over)
         self.assertIsInstance(final_score, int)


### PR DESCRIPTION
## Summary

Implements issue #2 - Corner Strategy agent for 2048 game.

### Changes
- **New agent**: `CornerAgent` in `game2048/agents/corner_agent.py`
- **Strategy**: Prioritizes down and right moves to keep high-value tiles in bottom-right corner
- **Fallback**: Uses left/up moves only when preferred moves are invalid

### Files Changed
- `game2048/agents/corner_agent.py` - New agent implementation
- `game2048/agents/__init__.py` - Export CornerAgent
- `test_game.py` - Unit tests for CornerAgent
- `benchmark.py` - Include corner agent in benchmarks

## Benchmark Results (50 seeds)

| Agent | Avg Score | Max Score | Avg Tile |
|-------|-----------|-----------|----------|
| corner | **2506.6** | 5688 | 202.2 |
| rightdown | 2545.9 | 5932 | 202.9 |
| random | 1124.6 | 2828 | 108.8 |
| rightleft | 721.6 | 1772 | 62.4 |

## Acceptance Criteria

- [x] Agent implemented and registered
- [x] Tests passing (20/20 tests pass)
- [x] Benchmark shows avg score > 1500 ✓ (2506.6)

Closes #2