### PR TITLE
feat: add Greedy agent that maximizes immediate score

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -12,6 +12,7 @@ from game2048.agents import (
     RightLeftAgent,
     RightDownAgent,
     CornerAgent,
+    GreedyAgent,
     BaseAgent,
 )
 from game2048.runner import GameRunner
@@ -104,6 +105,7 @@ def main():
         "rightleft": RightLeftAgent(),
         "rightdown": RightDownAgent(),
         "corner": CornerAgent(),
+        "greedy": GreedyAgent(),
     }
 
     all_results: dict[str, list[dict]] = {}

--- a/game2048/agents/__init__.py
+++ b/game2048/agents/__init__.py
@@ -39,6 +39,7 @@ from game2048.agents.random_agent import RandomAgent
 from game2048.agents.rightleft_agent import RightLeftAgent
 from game2048.agents.rightdown_agent import RightDownAgent
 from game2048.agents.corner_agent import CornerAgent
+from game2048.agents.greedy_agent import GreedyAgent
 
 __all__ = [
     "BaseAgent",
@@ -46,6 +47,7 @@ __all__ = [
     "RightLeftAgent",
     "RightDownAgent",
     "CornerAgent",
+    "GreedyAgent",
     "register_agent",
     "get_agent",
     "list_agents",

--- a/game2048/agents/greedy_agent.py
+++ b/game2048/agents/greedy_agent.py
@@ -1,0 +1,86 @@
+from typing import List, Optional, Tuple
+from game2048.game import Game2048
+from game2048.agents import register_agent, BaseAgent
+
+
+@register_agent("greedy")
+class GreedyAgent(BaseAgent):
+    def __init__(self, tie_breaker: List[str] = None):
+        self.tie_breaker = tie_breaker or ["down", "right", "left", "up"]
+
+    def choose_move(self, game: Game2048) -> Optional[str]:
+        valid = game.get_valid_moves()
+        if not valid:
+            return None
+
+        best_move = None
+        best_score = -1
+
+        for move in valid:
+            score_gain = self._simulate_score_gain(game, move)
+            if score_gain > best_score:
+                best_score = score_gain
+                best_move = move
+            elif score_gain == best_score and best_move is not None:
+                for preferred in self.tie_breaker:
+                    if preferred == move:
+                        best_move = move
+                        break
+                    if preferred == best_move:
+                        break
+
+        return best_move
+
+    def _simulate_score_gain(self, game: Game2048, move: str) -> int:
+        grid = game.grid
+        if move == Game2048.LEFT:
+            _, score, _ = self._move_left(grid)
+        elif move == Game2048.RIGHT:
+            reversed_grid = self._reverse_rows(grid)
+            _, score, _ = self._move_left(reversed_grid)
+        elif move == Game2048.UP:
+            transposed = self._transpose(grid)
+            _, score, _ = self._move_left(transposed)
+        elif move == Game2048.DOWN:
+            transposed = self._transpose(grid)
+            reversed_grid = self._reverse_rows(transposed)
+            _, score, _ = self._move_left(reversed_grid)
+        else:
+            score = 0
+        return score
+
+    def _compress_row(self, row: List[int]) -> Tuple[List[int], int]:
+        compressed = [x for x in row if x != 0]
+        score = 0
+        result = []
+        i = 0
+        while i < len(compressed):
+            if i + 1 < len(compressed) and compressed[i] == compressed[i + 1]:
+                merged_value = compressed[i] * 2
+                result.append(merged_value)
+                score += merged_value
+                i += 2
+            else:
+                result.append(compressed[i])
+                i += 1
+        while len(result) < 4:
+            result.append(0)
+        return result, score
+
+    def _move_left(self, grid: List[List[int]]) -> Tuple[List[List[int]], int, bool]:
+        new_grid = []
+        total_score = 0
+        moved = False
+        for row in grid:
+            new_row, score = self._compress_row(row)
+            new_grid.append(new_row)
+            total_score += score
+            if new_row != row:
+                moved = True
+        return new_grid, total_score, moved
+
+    def _transpose(self, grid: List[List[int]]) -> List[List[int]]:
+        return [[grid[j][i] for j in range(4)] for i in range(4)]
+
+    def _reverse_rows(self, grid: List[List[int]]) -> List[List[int]]:
+        return [row[::-1] for row in grid]

--- a/test_game.py
+++ b/test_game.py
@@ -1,6 +1,12 @@
 import unittest
 from game2048.game import Game2048
-from game2048.agents import RandomAgent, RightLeftAgent, RightDownAgent, CornerAgent
+from game2048.agents import (
+    RandomAgent,
+    RightLeftAgent,
+    RightDownAgent,
+    CornerAgent,
+    GreedyAgent,
+)
 
 
 class TestGame2048(unittest.TestCase):
@@ -154,6 +160,49 @@ class TestCornerAgent(unittest.TestCase):
     def test_play_game(self):
         game = Game2048(seed=42)
         agent = CornerAgent()
+        final_score = agent.play_game(game)
+        self.assertTrue(game.game_over)
+        self.assertIsInstance(final_score, int)
+        self.assertGreater(final_score, 0)
+
+
+class TestGreedyAgent(unittest.TestCase):
+    def test_agent_prefers_merge_moves(self):
+        # Grid where left/right gives higher score than up/down
+        game = Game2048(seed=42)
+        game.grid = [[2, 2, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]]
+        game.game_over = False
+        agent = GreedyAgent()
+        move = agent.choose_move(game)
+        # Left or right should be preferred (merges the 2s for 4 points)
+        # vs up/down which just moves the tile
+        self.assertIn(move, ["left", "right"])
+
+    def test_agent_uses_tie_breaker(self):
+        game = Game2048(seed=42)
+        game.grid = [[2, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]]
+        game.game_over = False
+        agent = GreedyAgent()
+        move = agent.choose_move(game)
+        self.assertEqual(move, "down")
+
+    def test_agent_returns_valid_move(self):
+        game = Game2048(seed=42)
+        agent = GreedyAgent()
+        move = agent.choose_move(game)
+        self.assertIn(move, Game2048.MOVES)
+
+    def test_agent_returns_none_when_no_moves(self):
+        game = Game2048(seed=42)
+        game.grid = [[2, 4, 2, 4], [4, 2, 4, 2], [2, 4, 2, 4], [4, 2, 4, 2]]
+        game.game_over = False
+        agent = GreedyAgent()
+        move = agent.choose_move(game)
+        self.assertIsNone(move)
+
+    def test_play_game(self):
+        game = Game2048(seed=42)
+        agent = GreedyAgent()
         final_score = agent.play_game(game)
         self.assertTrue(game.game_over)
         self.assertIsInstance(final_score, int)


### PR DESCRIPTION
## Summary

Implements issue #4 - Greedy agent for 2048 game.

## Algorithm

The Greedy agent picks the move that gives the highest immediate score increase:
1. For each valid move, simulates the move and calculates score gain
2. Picks the move with maximum score gain
3. Uses tie-breaker (down > right > left > up) for moves with equal scores

## Files Changed

- `game2048/agents/greedy_agent.py` - New agent with score simulation
- `game2048/agents/__init__.py` - Export GreedyAgent
- `test_game.py` - Unit tests for GreedyAgent
- `benchmark.py` - Include greedy agent in benchmarks

## Benchmark Results (50 seeds)

| Agent | Avg Score | Max Score | Avg Tile |
|-------|-----------|-----------|----------|
| **greedy** | **3179.0** | 7668 | 235.5 |
| rightdown | 2545.9 | 5932 | 202.9 |
| corner | 2506.6 | 5688 | 202.2 |
| random | 1124.6 | 2828 | 108.8 |
| rightleft | 721.6 | 1772 | 62.4 |

## Acceptance Criteria

- [x] Agent always picks move with max immediate score
- [x] Tests verify greedy behavior (5 tests, all passing)
- [x] Benchmark shows avg score 3179.0 > 1000 requirement ✓
- [x] Outperforms all other agents!

Closes #4