### PR TITLE
fix: use master branch in GitHub raw URL

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -240,7 +240,7 @@
     </div>
 
     <script>
-        const DATA_URL = 'https://raw.githubusercontent.com/openclaw43/2048-leaderboard/main/benchmark_results.json';
+        const DATA_URL = 'https://raw.githubusercontent.com/openclaw43/2048-leaderboard/master/benchmark_results.json';
         const LOCAL_URL = '../benchmark_results.json';
         
         const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;


### PR DESCRIPTION
Fixes the data URL in site/index.html to use 'master' instead of 'main' branch.