### PR TITLE
ci: add manual workflow trigger

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,6 +16,7 @@ on:
       - 'benchmark.py'
       - 'pyproject.toml'
       - '.github/workflows/benchmark.yml'
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Adds workflow_dispatch trigger to allow manually running the benchmark from GitHub Actions UI.