### PR TITLE
ci: handle protected branch gracefully

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -193,9 +193,10 @@ jobs:
       
       - name: Commit results to master
         if: github.ref == 'refs/heads/master'
+        continue-on-error: true
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add benchmark_results.json
           git diff --quiet --cached || git commit -m "Update benchmark results [skip ci]"
-          git push
+          git push || echo "Note: Could not push to protected branch. Results are available as artifact."


### PR DESCRIPTION
Adds continue-on-error to the commit step so the workflow doesn't fail when master is protected. The benchmark results are still uploaded as artifacts.