### PR TITLE
feat: add extended statistics with win rates, percentiles, and consistency

### DIFF
--- a/STATISTICS.md
+++ b/STATISTICS.md
@@ -1,10 +1,20 @@
 # Statistical Methodology
 
-This document describes the statistical methods used in the 2048 AI Leaderboard to provide confidence intervals and rank ranges.
+This document describes the statistical methods used in the 2048 AI Leaderboard to provide confidence intervals, rank ranges, and extended statistics.
 
 ## Overview
 
-Instead of showing exact rankings that may be misleading due to random variance, we use statistical significance testing to group agents into performance tiers.
+Instead of showing exact rankings that may be misleading due to random variance, we use statistical significance testing to group agents into performance tiers. We also provide extended statistics including distribution metrics, win rates, game length statistics, and consistency scores.
+
+## Basic Statistics
+
+### Summary Statistics
+
+For each agent, we compute:
+- **Average Score**: Mean score across all games
+- **Max Score**: Highest score achieved
+- **Min Score**: Lowest score achieved
+- **Avg Max Tile**: Average maximum tile achieved
 
 ## Confidence Intervals
 
@@ -61,6 +71,73 @@ Example output:
 }
 ```
 
+## Extended Statistics
+
+### Distribution Metrics
+
+We compute several distribution metrics to characterize score spread:
+
+- **Median**: The middle value (50th percentile), more robust to outliers than mean
+- **Standard Deviation**: Measure of score variability
+- **Percentiles**: 25th, 75th, 90th, and 99th percentiles
+- **Interquartile Range (IQR)**: 75th - 25th percentile, measuring middle 50% spread
+
+```python
+def compute_distribution_metrics(scores):
+    return {
+        "median": np.median(scores),
+        "std_dev": np.std(scores, ddof=1),
+        "percentile_25": np.percentile(scores, 25),
+        "percentile_75": np.percentile(scores, 75),
+        "percentile_90": np.percentile(scores, 90),
+        "percentile_99": np.percentile(scores, 99),
+        "iqr": np.percentile(scores, 75) - np.percentile(scores, 25),
+    }
+```
+
+### Win Rates
+
+Win rates measure the percentage of games where an agent achieves a certain tile threshold:
+
+- **reached_512**: % of games reaching 512 tile
+- **reached_1024**: % of games reaching 1024 tile
+- **reached_2048**: % of games reaching 2048 tile (the "win" condition)
+
+```python
+def compute_win_rates(results, thresholds=[512, 1024, 2048]):
+    win_rates = {}
+    for threshold in thresholds:
+        count = sum(1 for r in results if r["max_tile"] >= threshold)
+        win_rates[f"reached_{threshold}"] = count / len(results) * 100
+    return win_rates
+```
+
+### Game Length Statistics
+
+Statistics about how many moves each game takes:
+
+- **Avg Moves**: Average number of moves per game
+- **Min Moves**: Fewest moves in any game
+- **Max Moves**: Most moves in any game
+- **Median Moves**: Median number of moves
+
+Longer games generally indicate better play, as the agent survives longer before the board fills up.
+
+### Consistency Score
+
+The **Coefficient of Variation (CV)** measures consistency as a percentage:
+
+```python
+cv = (std_dev / mean) * 100
+```
+
+- **Lower CV = More Consistent**: The agent produces similar scores each game
+- **Higher CV = Less Consistent**: The agent has high variance in scores
+
+For example:
+- CV of 20%: Scores are fairly consistent around the mean
+- CV of 50%: Scores vary widely from game to game
+
 ## Significance Level (α)
 
 The default significance level is α = 0.05, which can be changed with the `--alpha` flag:
@@ -81,21 +158,78 @@ python benchmark.py --alpha 0.10  # Less strict (more ties)
 
 ## Display Format
 
-### PR Comments
+### Console Output
 
-| Rank | Agent | Avg Score | 95% CI | Max Score | Avg Max Tile |
-|------|-------|-----------|--------|-----------|-------------|
-| 1st | mcts | 18,472 | [17,638, 19,306] | 24,580 | 2,048 |
-| 2nd-3rd | expectimax | 16,710 | [15,954, 17,466] | 22,140 | 1,932 |
-| 2nd-3rd | heuristic | 16,500 | [15,711, 17,289] | 21,890 | 1,876 |
+```
+COMPARISON (with 95% confidence intervals)
+====================================================================================================
+Rank         Agent        Avg Score   Median  Std Dev           95% CI Consistency
+----------------------------------------------------------------------------------------------------
+🥇 1st       mcts           18472.0    19200    4234  [17638, 19306]      22.9%
+🥈 2nd-3rd   expectimax     16710.0    17100    3890  [15954, 17466]      23.3%
+...
+
+WIN RATES (% reaching tile threshold)
+================================================================================
+Agent          2048      1024       512
+--------------------------------------------------
+mcts           78.0%     94.0%     99.0%
+...
+
+GAME LENGTH
+============================================================
+Agent          Avg Moves      Min      Max
+--------------------------------------------------
+mcts             892.0      450     1200
+...
+```
+
+### JSON Output
+
+The `--json` output includes all extended statistics:
+
+```json
+{
+  "extended": {
+    "agent_name": {
+      "distribution": {
+        "median": 19200.0,
+        "std_dev": 4234.5,
+        "percentile_25": 16000.0,
+        "percentile_75": 21000.0,
+        "percentile_90": 23000.0,
+        "percentile_99": 24500.0,
+        "iqr": 5000.0
+      },
+      "win_rates": {
+        "reached_512": 99.0,
+        "reached_1024": 94.0,
+        "reached_2048": 78.0
+      },
+      "game_length": {
+        "avg_moves": 892.0,
+        "min_moves": 450,
+        "max_moves": 1200,
+        "median_moves": 900.0
+      },
+      "consistency": {
+        "coefficient_of_variation": 22.9
+      }
+    }
+  }
+}
+```
 
 ### Site Visualization
 
-- Error bars on bar charts show 95% confidence intervals
-- Agents with overlapping confidence intervals may be tied
-- Hover tooltips show exact confidence interval values
+- **Leaderboard Table**: Shows rank, agent, avg score, median, std dev, 95% CI, and consistency
+- **Win Rates Table**: Shows % reaching 2048, 1024, and 512 tiles
+- **Win Rates Chart**: Grouped bar chart comparing tile achievement rates
+- **Consistency Chart**: Horizontal bar chart showing CV (lower = more consistent)
+- **Radar Chart**: Multi-dimensional comparison including score, consistency, 2048 rate, and max tile
 
 ## References
 
 - Welch, B. L. (1947). "The generalization of 'Student's' problem when several different population variances are involved"
 - scipy.stats.ttest_ind documentation: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.ttest_ind.html
+- Coefficient of Variation: https://en.wikipedia.org/wiki/Coefficient_of_variation

--- a/game2048/stats.py
+++ b/game2048/stats.py
@@ -15,12 +15,47 @@ class SummaryStats(TypedDict):
     avg_max_tile: float
 
 
+class DistributionMetrics(TypedDict):
+    median: float
+    std_dev: float
+    percentile_25: float
+    percentile_75: float
+    percentile_90: float
+    percentile_99: float
+    iqr: float
+
+
+class WinRates(TypedDict):
+    reached_512: float
+    reached_1024: float
+    reached_2048: float
+
+
+class GameLengthStats(TypedDict):
+    avg_moves: float
+    min_moves: int
+    max_moves: int
+    median_moves: float
+
+
+class ConsistencyScore(TypedDict):
+    coefficient_of_variation: float
+
+
+class ExtendedStats(TypedDict):
+    distribution: DistributionMetrics
+    win_rates: WinRates
+    game_length: GameLengthStats
+    consistency: ConsistencyScore
+
+
 class StatisticsResult(TypedDict):
     summaries: dict[str, SummaryStats]
     confidence_intervals: dict[str, tuple[float, float]]
     rank_ranges: dict[str, tuple[int, int]]
     alpha: float
     confidence: float
+    extended: dict[str, ExtendedStats]
 
 
 def confidence_interval(
@@ -48,6 +83,69 @@ def is_significantly_different(
     result = stats.ttest_ind(scores_a, scores_b, equal_var=False)
     p_value = float(result.pvalue)
     return p_value < alpha
+
+
+def compute_distribution_metrics(scores: list[int]) -> DistributionMetrics:
+    if not scores:
+        return DistributionMetrics(
+            median=0.0,
+            std_dev=0.0,
+            percentile_25=0.0,
+            percentile_75=0.0,
+            percentile_90=0.0,
+            percentile_99=0.0,
+            iqr=0.0,
+        )
+    scores_arr = np.array(scores)
+    p25 = float(np.percentile(scores_arr, 25))
+    p75 = float(np.percentile(scores_arr, 75))
+    return DistributionMetrics(
+        median=float(np.median(scores_arr)),
+        std_dev=float(np.std(scores_arr, ddof=1)),
+        percentile_25=p25,
+        percentile_75=p75,
+        percentile_90=float(np.percentile(scores_arr, 90)),
+        percentile_99=float(np.percentile(scores_arr, 99)),
+        iqr=p75 - p25,
+    )
+
+
+def compute_win_rates(results: list[dict[str, int]]) -> WinRates:
+    if not results:
+        return WinRates(reached_512=0.0, reached_1024=0.0, reached_2048=0.0)
+    total = len(results)
+    reached_512 = sum(1 for r in results if r["max_tile"] >= 512)
+    reached_1024 = sum(1 for r in results if r["max_tile"] >= 1024)
+    reached_2048 = sum(1 for r in results if r["max_tile"] >= 2048)
+    return WinRates(
+        reached_512=round(reached_512 / total * 100, 1),
+        reached_1024=round(reached_1024 / total * 100, 1),
+        reached_2048=round(reached_2048 / total * 100, 1),
+    )
+
+
+def compute_game_length_stats(results: list[dict[str, int]]) -> GameLengthStats:
+    if not results:
+        return GameLengthStats(
+            avg_moves=0.0, min_moves=0, max_moves=0, median_moves=0.0
+        )
+    moves = [r["moves"] for r in results]
+    return GameLengthStats(
+        avg_moves=round(float(np.mean(moves)), 1),
+        min_moves=int(min(moves)),
+        max_moves=int(max(moves)),
+        median_moves=float(np.median(moves)),
+    )
+
+
+def compute_consistency_score(scores: list[int]) -> ConsistencyScore:
+    if not scores:
+        return ConsistencyScore(coefficient_of_variation=0.0)
+    mean = float(np.mean(scores))
+    if mean == 0:
+        return ConsistencyScore(coefficient_of_variation=0.0)
+    std_dev = float(np.std(scores, ddof=1))
+    return ConsistencyScore(coefficient_of_variation=round(std_dev / mean * 100, 1))
 
 
 def compute_rank_ranges(
@@ -133,6 +231,7 @@ def compute_all_statistics(
     all_scores: dict[str, list[int]] = {}
     summaries: dict[str, SummaryStats] = {}
     confidence_intervals: dict[str, tuple[float, float]] = {}
+    extended: dict[str, ExtendedStats] = {}
 
     for agent_name, results in all_results.items():
         scores = [r["score"] for r in results]
@@ -141,11 +240,18 @@ def compute_all_statistics(
         all_scores[agent_name] = scores
         summaries[agent_name] = SummaryStats(
             avg_score=round(float(np.mean(scores)), 1),
-            max_score=int(max(scores)),
-            min_score=int(min(scores)),
+            max_score=int(max(scores)) if scores else 0,
+            min_score=int(min(scores)) if scores else 0,
             avg_max_tile=round(float(np.mean(max_tiles)), 1),
         )
         confidence_intervals[agent_name] = confidence_interval(scores, confidence)
+
+        extended[agent_name] = ExtendedStats(
+            distribution=compute_distribution_metrics(scores),
+            win_rates=compute_win_rates(results),
+            game_length=compute_game_length_stats(results),
+            consistency=compute_consistency_score(scores),
+        )
 
     rank_ranges = compute_rank_ranges(all_scores, alpha)
 
@@ -155,4 +261,5 @@ def compute_all_statistics(
         rank_ranges=rank_ranges,
         alpha=alpha,
         confidence=confidence,
+        extended=extended,
     )

--- a/site/index.html
+++ b/site/index.html
@@ -193,14 +193,31 @@
                         <th>Rank</th>
                         <th>Agent</th>
                         <th>Avg Score</th>
+                        <th>Median</th>
+                        <th>Std Dev</th>
                         <th>95% CI</th>
-                        <th>Max Score</th>
-                        <th>Min Score</th>
-                        <th>Avg Max Tile</th>
+                        <th>Consistency</th>
                     </tr>
                 </thead>
                 <tbody id="leaderboard">
                     <tr><td colspan="7" class="loading">Loading...</td></tr>
+                </tbody>
+            </table>
+        </div>
+        
+        <div class="card">
+            <h2>Win Rates (% reaching tile)</h2>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Agent</th>
+                        <th>2048</th>
+                        <th>1024</th>
+                        <th>512</th>
+                    </tr>
+                </thead>
+                <tbody id="winRatesTable">
+                    <tr><td colspan="4" class="loading">Loading...</td></tr>
                 </tbody>
             </table>
         </div>
@@ -221,9 +238,16 @@
             </div>
             
             <div class="card">
-                <h2>Max Tile Distribution</h2>
+                <h2>Win Rates Comparison</h2>
                 <div class="chart-container">
-                    <canvas id="maxTileChart"></canvas>
+                    <canvas id="winRatesChart"></canvas>
+                </div>
+            </div>
+            
+            <div class="card">
+                <h2>Consistency (Lower CV = More Consistent)</h2>
+                <div class="chart-container">
+                    <canvas id="consistencyChart"></canvas>
                 </div>
             </div>
             
@@ -231,6 +255,13 @@
                 <h2>Agent Comparison</h2>
                 <div class="chart-container">
                     <canvas id="radarChart"></canvas>
+                </div>
+            </div>
+            
+            <div class="card">
+                <h2>Max Tile Distribution</h2>
+                <div class="chart-container">
+                    <canvas id="maxTileChart"></canvas>
                 </div>
             </div>
         </div>
@@ -269,10 +300,11 @@
                 if (!response.ok) throw new Error('Failed to load data');
                 benchmarkData = await response.json();
                 renderLeaderboard();
+                renderWinRates();
                 renderCharts();
             } catch (error) {
                 document.getElementById('leaderboard').innerHTML = 
-                    '<tr><td colspan="6" class="error">Error loading benchmark data</td></tr>';
+                    '<tr><td colspan="7" class="error">Error loading benchmark data</td></tr>';
                 document.getElementById('lastUpdated').textContent = 'Error loading data';
             }
         }
@@ -281,24 +313,29 @@
             const summary = benchmarkData.summary || {};
             const confidenceIntervals = benchmarkData.confidence_intervals || {};
             const rankRanges = benchmarkData.rank_ranges || {};
+            const extended = benchmarkData.extended || {};
             const sorted = Object.entries(summary).sort((a, b) => b[1].avg_score - a[1].avg_score);
             
             const tbody = document.getElementById('leaderboard');
             tbody.innerHTML = sorted.map(([agent, stats], i) => {
                 const rankInfo = rankRanges[agent] || { display: `#${i + 1}` };
                 const ci = confidenceIntervals[agent] || { lower: stats.avg_score, upper: stats.avg_score };
+                const ext = extended[agent] || { distribution: {}, consistency: {} };
                 const ciDisplay = `[${Math.round(ci.lower).toLocaleString()}, ${Math.round(ci.upper).toLocaleString()}]`;
                 const rankDisplay = rankInfo.display || `#${i + 1}`;
                 const rankClass = rankInfo.min <= 3 ? `rank-${rankInfo.min}` : '';
+                const median = ext.distribution.median || stats.avg_score;
+                const stdDev = ext.distribution.std_dev || 0;
+                const consistency = ext.consistency.coefficient_of_variation || 0;
                 return `
                     <tr>
                         <td class="rank ${rankClass}">${rankDisplay}</td>
                         <td class="agent-name">${agent}</td>
                         <td class="score">${stats.avg_score.toLocaleString()}</td>
+                        <td>${Math.round(median).toLocaleString()}</td>
+                        <td>${Math.round(stdDev).toLocaleString()}</td>
                         <td>${ciDisplay}</td>
-                        <td>${stats.max_score.toLocaleString()}</td>
-                        <td>${stats.min_score.toLocaleString()}</td>
-                        <td>${Math.round(stats.avg_max_tile).toLocaleString()}</td>
+                        <td>${consistency.toFixed(1)}%</td>
                     </tr>
                 `;
             }).join('');
@@ -307,6 +344,26 @@
                 ? new Date(benchmarkData.timestamp).toLocaleString() 
                 : 'Unknown';
             document.getElementById('lastUpdated').textContent = `Last updated: ${timestamp}`;
+        }
+        
+        function renderWinRates() {
+            const extended = benchmarkData.extended || {};
+            const summary = benchmarkData.summary || {};
+            const sorted = Object.entries(summary).sort((a, b) => b[1].avg_score - a[1].avg_score);
+            
+            const tbody = document.getElementById('winRatesTable');
+            tbody.innerHTML = sorted.map(([agent]) => {
+                const ext = extended[agent] || { win_rates: {} };
+                const wr = ext.win_rates || {};
+                return `
+                    <tr>
+                        <td class="agent-name">${agent}</td>
+                        <td>${(wr.reached_2048 || 0).toFixed(1)}%</td>
+                        <td>${(wr.reached_1024 || 0).toFixed(1)}%</td>
+                        <td>${(wr.reached_512 || 0).toFixed(1)}%</td>
+                    </tr>
+                `;
+            }).join('');
         }
         
         function getBarColors(count) {
@@ -322,6 +379,7 @@
         
         function renderCharts() {
             const summary = benchmarkData.summary || {};
+            const extended = benchmarkData.extended || {};
             const agents = Object.keys(summary);
             const sorted = Object.entries(summary).sort((a, b) => b[1].avg_score - a[1].avg_score);
             const sortedAgents = sorted.map(s => s[0]);
@@ -383,6 +441,73 @@
                 }
             });
             
+            new Chart(document.getElementById('winRatesChart'), {
+                type: 'bar',
+                data: {
+                    labels: sortedAgents,
+                    datasets: [
+                        {
+                            label: '2048',
+                            data: sortedAgents.map(a => (extended[a]?.win_rates?.reached_2048 || 0)),
+                            backgroundColor: '#27ae60',
+                            borderRadius: 4
+                        },
+                        {
+                            label: '1024',
+                            data: sortedAgents.map(a => (extended[a]?.win_rates?.reached_1024 || 0)),
+                            backgroundColor: '#3498db',
+                            borderRadius: 4
+                        },
+                        {
+                            label: '512',
+                            data: sortedAgents.map(a => (extended[a]?.win_rates?.reached_512 || 0)),
+                            backgroundColor: '#f39c12',
+                            borderRadius: 4
+                        }
+                    ]
+                },
+                options: {
+                    indexAxis: 'y',
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    scales: {
+                        x: { max: 100, title: { display: true, text: '%' } }
+                    },
+                    plugins: { legend: { position: 'bottom' } }
+                }
+            });
+            
+            const consistencyData = sortedAgents.map(a => extended[a]?.consistency?.coefficient_of_variation || 0);
+            new Chart(document.getElementById('consistencyChart'), {
+                type: 'bar',
+                data: {
+                    labels: sortedAgents,
+                    datasets: [{
+                        label: 'CV (%)',
+                        data: consistencyData,
+                        backgroundColor: sortedAgents.map((_, i) => 
+                            i === 0 ? chartColors.gold : 
+                            i === 1 ? chartColors.silver : 
+                            i === 2 ? chartColors.bronze : chartColors.primary
+                        ),
+                        borderRadius: 6
+                    }]
+                },
+                options: {
+                    indexAxis: 'y',
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    plugins: { 
+                        legend: { display: false },
+                        tooltip: {
+                            callbacks: {
+                                label: (ctx) => `CV: ${ctx.raw.toFixed(1)}% (Lower is more consistent)`
+                            }
+                        }
+                    }
+                }
+            });
+            
             const tileBuckets = { '512+': 0, '256': 0, '128': 0, '64': 0, '<64': 0 };
             const agentGames = benchmarkData.agents || {};
             
@@ -418,23 +543,13 @@
             
             const maxScores = Math.max(...Object.values(summary).map(s => s.max_score));
             const maxTiles = Math.max(...Object.values(summary).map(s => s.avg_max_tile));
-            const maxStd = Math.max(...Object.values(summary).map(s => {
-                const games = agentGames[s] || [];
-                const avg = summary[Object.keys(summary).find(k => {
-                    const agentGames2 = benchmarkData.agents[k];
-                    return agentGames2 === games;
-                })]?.avg_score || 0;
-                const variance = games.reduce((sum, g) => sum + Math.pow(g.score - avg, 2), 0) / games.length;
-                return Math.sqrt(variance);
-            }));
+            const maxCV = Math.max(...consistencyData) || 1;
             
             const radarData = sortedAgents.map(agent => {
-                const games = benchmarkData.agents[agent] || [];
-                const avg = summary[agent].avg_score;
-                const variance = games.reduce((sum, g) => sum + Math.pow(g.score - avg, 2), 0) / games.length;
-                const stdDev = Math.sqrt(variance);
-                const consistency = maxStd > 0 ? ((maxStd - stdDev) / maxStd) * 100 : 100;
-                const maxTileRate = games.filter(g => g.max_tile >= 2048).length / games.length * 100;
+                const ext = extended[agent] || {};
+                const cv = ext.consistency?.coefficient_of_variation || 0;
+                const consistency = ((maxCV - cv) / maxCV) * 100;
+                const maxTileRate = ext.win_rates?.reached_2048 || 0;
                 
                 return {
                     label: agent,


### PR DESCRIPTION
## Summary

Adds comprehensive extended statistics to provide deeper insights into agent performance.

## New Statistics

### Distribution Metrics
- Median score
- Standard deviation
- Percentiles (25th, 75th, 90th, 99th)
- Interquartile range (IQR)

### Win Rates
- % of games reaching 2048
- % of games reaching 1024
- % of games reaching 512

### Game Length
- Average moves
- Min/Max moves
- Median moves

### Consistency
- Coefficient of variation (CV) - lower is more consistent

## Changes

- **game2048/stats.py**: New TypedDict classes and computation functions
- **benchmark.py**: Extended output in comparison tables
- **site/index.html**: New Win Rates table and charts
- **STATISTICS.md**: Documentation for all new metrics

## Site Enhancements

- Leaderboard now shows: Median, Std Dev, Consistency
- New Win Rates table section
- Win Rates Comparison chart (grouped bar)
- Consistency chart (horizontal bar)
- Updated radar chart

## Example Output



## Testing
- ✅ All 48 tests pass
- ✅ mypy --strict clean

Closes #37