### PR TITLE
feat: add LLM Agent with game history (Issue #55)

### DIFF
--- a/game2048/agents/__init__.py
+++ b/game2048/agents/__init__.py
@@ -48,7 +48,7 @@ from game2048.agents.expectimax_agent import ExpectimaxAgent
 from game2048.agents.mcts_agent import MCTSAgent
 from game2048.agents.td_learning_agent import TDLearningAgent
 from game2048.agents.apprentice_agent import ApprenticeAgent
-from game2048.agents.llm_agent import LLMAgent
+from game2048.agents.llm_agent import LLMAgent, LLMHistoryAgent
 
 __all__: list[str] = [
     "BaseAgent",
@@ -63,6 +63,7 @@ __all__: list[str] = [
     "TDLearningAgent",
     "ApprenticeAgent",
     "LLMAgent",
+    "LLMHistoryAgent",
     "register_agent",
     "get_agent",
     "list_agents",


### PR DESCRIPTION
## Summary
Create an LLM agent that uses game history (last N moves) to make strategic decisions.

## Implementation

### LLMHistoryAgent
- Extends LLMAgent with history tracking
- Maintains list of last N (board, move, score) tuples
- Formats prompt with full game context
- Configurable history_size (default 5)

### Usage
```bash
# Run with history tracking
uv run --env-file ~/.env.openrouter python scripts/benchmark_llm.py --history

# Custom history size
uv run --env-file ~/.env.openrouter python scripts/benchmark_llm.py --history --history-size 10
```

## Files Changed
- game2048/agents/llm_agent.py - Added LLMHistoryAgent class
- game2048/agents/__init__.py - Export LLMHistoryAgent
- scripts/benchmark_llm.py - Added --history support

## Testing
- All 56 tests pass
- mypy --strict passes

Depends on: #54
Closes #55
